### PR TITLE
Direct list fixes

### DIFF
--- a/lib/cpp/scalgoproto.hh
+++ b/lib/cpp/scalgoproto.hh
@@ -751,7 +751,7 @@ class DirectListIn : public In {
 		: reader_(reader)
 		, start_(p.start+8)
 		, size_(p.size)
-		, item_size_(parse_header(reader, p)) {}
+		, item_size_(p.size == 0 ? 1 : parse_header(reader, p)) {}
 public:
 	using value_type = T;
 	using size_type = std::size_t;

--- a/lib/cpp/scalgoproto.hh
+++ b/lib/cpp/scalgoproto.hh
@@ -822,9 +822,9 @@ protected:
 			  std::uint64_t add = 0>
 	Ptr getPtr_() const {
 		if constexpr (inplace)
-			return reader_->getPtrInplace_<mult, add>(start_ + size_, read48_(start_ + o));
+			return reader_->getPtrInplace_<mult, add>(start_ + size_, get48_<o>());
 		else
-			return reader_->getPtr_<magic, mult, add>(read48_(start_ + o));
+			return reader_->getPtr_<magic, mult, add>(get48_<o>());
 	}
 
 	template <std::uint64_t o, std::uint8_t bit, std::uint8_t def>


### PR DESCRIPTION
When a direct list is added to a table schema, attempts to read the direct list from a table written before the direct list is added results in an out of bounds read.