### PR TITLE
Fix changed field indices after removal

### DIFF
--- a/scalgoprotoc/cpp_generator.py
+++ b/scalgoprotoc/cpp_generator.py
@@ -912,8 +912,7 @@ class Generator:
                 "\tusing IN=%sIn<%s>;" % (union.name, "true" if inplace else "false")
             )
             self.o("\tType type() const noexcept {return (Type)this->getType_();}")
-            idx = 1
-            for member in union.members:
+            for idx, member in enumerate(union.members):
                 assert member.type_ is not None
                 if member.type_.type == TokenType.REMOVED:
                     continue
@@ -929,7 +928,6 @@ class Generator:
                     self.generate_union_text_out(member, uname, inplace, idx)
                 else:
                     raise ICE()
-                idx += 1
             self.generate_union_copy(union, inplace)
             self.o("};")
             self.output_metamagic(

--- a/scalgoprotoc/python_generator.py
+++ b/scalgoprotoc/python_generator.py
@@ -1049,8 +1049,7 @@ class Generator:
         )
         self.o("        super().__init__(writer, offset, end)")
         self.o()
-        idx = 1
-        for member in union.members:
+        for idx, member in enumerate(union.members):
             assert member.type_ is not None
             if member.type_.type == TokenType.REMOVED:
                 continue
@@ -1065,7 +1064,6 @@ class Generator:
                 self.generate_union_text_out(member, uuname, idx, False)
             else:
                 raise ICE()
-            idx += 1
         self.generate_union_copy(union)
         self.o()
 

--- a/scalgoprotoc/ts_generator.py
+++ b/scalgoprotoc/ts_generator.py
@@ -825,9 +825,10 @@ class Generator:
         self.o("\t\tsuper(writer, offset, end);")
         self.o("\t}")
         self.o()
-        idx = 1
-        for member in union.members:
+        for idx, member in enumerate(union.members):
             llname = lcamel(self.value(member.identifier))
+            if member.type_.type == TokenType.REMOVED:
+                continue
             if member.list_:
                 self.generate_union_list_out(member, llname, idx, False)
             elif member.table:
@@ -838,7 +839,6 @@ class Generator:
                 self.generate_union_text_out(member, llname, idx, False)
             else:
                 raise ICE()
-            idx += 1
         self.generate_union_copy(union)
         self.o("}")
         self.o()


### PR DESCRIPTION
For some generators we did not retain the index / id of fields if prior fields had been removed.