### PR TITLE
use enumurate to generators

### DIFF
--- a/scalgoprotoc/cpp_generator.py
+++ b/scalgoprotoc/cpp_generator.py
@@ -912,20 +912,20 @@ class Generator:
                 "\tusing IN=%sIn<%s>;" % (union.name, "true" if inplace else "false")
             )
             self.o("\tType type() const noexcept {return (Type)this->getType_();}")
-            for idx, member in enumerate(union.members):
+            for idx, member in enumerate(union.members, start=1):
                 assert member.type_ is not None
                 if member.type_.type == TokenType.REMOVED:
                     continue
                 n = self.value(member.identifier)
                 uname = ucamel(n)
                 if member.list_:
-                    self.generate_union_list_out(member, uname, inplace, idx + 1)
+                    self.generate_union_list_out(member, uname, inplace, idx)
                 elif member.table:
-                    self.generate_union_table_out(member, uname, inplace, idx + 1)
+                    self.generate_union_table_out(member, uname, inplace, idx)
                 elif member.type_.type == TokenType.BYTES:
-                    self.generate_union_bytes_out(member, uname, inplace, idx + 1)
+                    self.generate_union_bytes_out(member, uname, inplace, idx)
                 elif member.type_.type == TokenType.TEXT:
-                    self.generate_union_text_out(member, uname, inplace, idx + 1)
+                    self.generate_union_text_out(member, uname, inplace, idx)
                 else:
                     raise ICE()
             self.generate_union_copy(union, inplace)
@@ -1127,13 +1127,11 @@ class Generator:
     def generate_enum(self, node: Enum) -> None:
         self.switch_namespace(node.namespace)
         self.o("enum class %s: std::uint8_t {" % node.name)
-        index = 0
-        for ev in node.members:
+        for idx, ev in enumerate(node.members):
             if ev.token is None:
                 raise ICE()
             self.output_doc(ev, "\t")
-            self.o("\t%s = %d," % (self.value(ev.token), index))
-            index += 1
+            self.o("\t%s = %d," % (self.value(ev.token), idx))
         self.o("};")
         self.output_metamagic(
             """template <> struct MetaMagic<%s> {using t=EnumTag;};

--- a/scalgoprotoc/python_generator.py
+++ b/scalgoprotoc/python_generator.py
@@ -1001,15 +1001,13 @@ class Generator:
         self.o()
         self.o("    class Type(enum.IntEnum):")
         self.o("        NONE = 0")
-        idx = 1
-        for member in union.members:
+        for idx, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             if member.type_.type == TokenType.REMOVED:
                 continue
             if not isinstance(member, (Table, Value)):
                 raise ICE()
             self.o("        %s = %d" % (self.value(member.identifier).upper(), idx))
-            idx += 1
         self.o()
         self.o("    @property")
         self.o("    def type(self) -> Type:")
@@ -1049,19 +1047,19 @@ class Generator:
         )
         self.o("        super().__init__(writer, offset, end)")
         self.o()
-        for idx, member in enumerate(union.members):
+        for idx, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             if member.type_.type == TokenType.REMOVED:
                 continue
             uuname = snake(self.value(member.identifier))
             if member.list_:
-                self.generate_union_list_out(member, uuname, idx + 1, False)
+                self.generate_union_list_out(member, uuname, idx, False)
             elif member.table:
-                self.generate_union_table_out(member, uuname, idx + 1, False)
+                self.generate_union_table_out(member, uuname, idx, False)
             elif member.type_.type == TokenType.BYTES:
-                self.generate_union_bytes_out(member, uuname, idx + 1, False)
+                self.generate_union_bytes_out(member, uuname, idx, False)
             elif member.type_.type == TokenType.TEXT:
-                self.generate_union_text_out(member, uuname, idx + 1, False)
+                self.generate_union_text_out(member, uuname, idx, False)
             else:
                 raise ICE()
         self.generate_union_copy(union)
@@ -1078,8 +1076,7 @@ class Generator:
         )
         self.o("        super().__init__(writer, offset, end)")
         self.o()
-        idx = 1
-        for member in union.members:
+        for idx, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             if member.type_.type == TokenType.REMOVED:
                 continue
@@ -1094,7 +1091,6 @@ class Generator:
                 self.generate_union_text_out(member, uuname, idx, True)
             else:
                 raise ICE()
-            idx += 1
         self.generate_union_copy(union)
         self.o()
 
@@ -1286,10 +1282,8 @@ class Generator:
     def generate_enum(self, node: Enum) -> None:
         self.o("class %s(enum.IntEnum):" % node.name)
         self.output_doc(node, "   ")
-        index = 0
-        for ev in node.members:
+        for index, ev in enumerate(node.members):
             self.o("    %s = %d" % (self.value(ev.identifier), index))
-            index += 1
         self.o()
         self.o()
 

--- a/scalgoprotoc/rust_generator.py
+++ b/scalgoprotoc/rust_generator.py
@@ -1031,29 +1031,29 @@ impl<'a> scalgoproto::UnionIn<'a> for {union.name}In<'a> {{
         -> Result<Self> {{
         match t {{"""
         )
-        for i, member in enumerate(union.members):
+        for i, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             uname = ucamel(self.value(member.identifier))
             if member.list_:
                 self.o(
-                    f"        {i+1} => Ok(Self::{uname}(reader.get_list_union(magic, offset, size)?)),"
+                    f"        {i} => Ok(Self::{uname}(reader.get_list_union(magic, offset, size)?)),"
                 )
             elif member.table:
                 self.o(
-                    f"        {i+1} => Ok(Self::{uname}(reader.get_table_union::<{member.table.name}In>(magic, offset, size)?)),"
+                    f"        {i} => Ok(Self::{uname}(reader.get_table_union::<{member.table.name}In>(magic, offset, size)?)),"
                 )
             elif member.type_.type == TokenType.BYTES:
                 self.o(
-                    f"        {i+1} => Ok(Self::{uname}(reader.get_bytes_union(magic, offset, size)?)),"
+                    f"        {i} => Ok(Self::{uname}(reader.get_bytes_union(magic, offset, size)?)),"
                 )
             elif member.type_.type == TokenType.TEXT:
                 self.o(
-                    f"        {i+1} => Ok(Self::{uname}(reader.get_text_union(magic, offset, size)?)),"
+                    f"        {i} => Ok(Self::{uname}(reader.get_text_union(magic, offset, size)?)),"
                 )
             elif member.type_.type == TokenType.REMOVED:
                 continue
             else:
-                self.o(f"        {i+1} => Ok(Self::None),")
+                self.o(f"        {i} => Ok(Self::None),")
 
         self.o(
             f"""        _ => Ok(Self::None),
@@ -1080,17 +1080,17 @@ impl<'a> {union.name}Out<'a, Normal> {{
     }}
 """
         )
-        for idx, member in enumerate(union.members):
+        for idx, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             llname = snake(self.value(member.identifier))
             if member.list_:
-                self.generate_union_list_out(member, llname, idx + 1, False)
+                self.generate_union_list_out(member, llname, idx, False)
             elif member.table:
-                self.generate_union_table_out(member, llname, idx + 1, False)
+                self.generate_union_table_out(member, llname, idx, False)
             elif member.type_.type == TokenType.BYTES:
-                self.generate_union_bytes_out(member, llname, idx + 1, False)
+                self.generate_union_bytes_out(member, llname, idx, False)
             elif member.type_.type == TokenType.TEXT:
-                self.generate_union_text_out(member, llname, idx + 1, False)
+                self.generate_union_text_out(member, llname, idx, False)
             elif member.type_.type == TokenType.REMOVED:
                 continue
             else:
@@ -1107,17 +1107,17 @@ impl<'a> {union.name}Out<'a, Inplace> {{
     }}
 """
         )
-        for idx, member in enumerate(union.members):
+        for idx, member in enumerate(union.members, start=1):
             assert member.type_ is not None
             llname = snake(self.value(member.identifier))
             if member.list_:
-                self.generate_union_list_out(member, llname, idx + 1, True)
+                self.generate_union_list_out(member, llname, idx, True)
             elif member.table:
-                self.generate_union_table_out(member, llname, idx + 1, True)
+                self.generate_union_table_out(member, llname, idx, True)
             elif member.type_.type == TokenType.BYTES:
-                self.generate_union_bytes_out(member, llname, idx + 1, True)
+                self.generate_union_bytes_out(member, llname, idx, True)
             elif member.type_.type == TokenType.TEXT:
-                self.generate_union_text_out(member, llname, idx + 1, True)
+                self.generate_union_text_out(member, llname, idx, True)
             elif member.type_.type == TokenType.REMOVED:
                 continue
             else:

--- a/scalgoprotoc/ts_generator.py
+++ b/scalgoprotoc/ts_generator.py
@@ -825,18 +825,18 @@ class Generator:
         self.o("\t\tsuper(writer, offset, end);")
         self.o("\t}")
         self.o()
-        for idx, member in enumerate(union.members):
+        for idx, member in enumerate(union.members, start=1):
             llname = lcamel(self.value(member.identifier))
             if member.type_.type == TokenType.REMOVED:
                 continue
             if member.list_:
-                self.generate_union_list_out(member, llname, idx + 1, False)
+                self.generate_union_list_out(member, llname, idx, False)
             elif member.table:
-                self.generate_union_table_out(member, llname, idx + 1, False)
+                self.generate_union_table_out(member, llname, idx, False)
             elif member.type_.type == TokenType.BYTES:
-                self.generate_union_bytes_out(member, llname, idx + 1, False)
+                self.generate_union_bytes_out(member, llname, idx, False)
             elif member.type_.type == TokenType.TEXT:
-                self.generate_union_text_out(member, llname, idx + 1, False)
+                self.generate_union_text_out(member, llname, idx, False)
             else:
                 raise ICE()
         self.generate_union_copy(union)
@@ -854,8 +854,7 @@ class Generator:
         self.o("\t\tsuper(writer, offset, end);")
         self.o("\t}")
         self.o()
-        idx = 1
-        for member in union.members:
+        for idx, member in enumerate(union.members, start=1):
             llname = lcamel(self.value(member.identifier))
             if member.list_:
                 self.generate_union_list_out(member, llname, idx, True)
@@ -867,7 +866,6 @@ class Generator:
                 self.generate_union_text_out(member, llname, idx, True)
             else:
                 raise ICE()
-            idx += 1
         self.generate_union_copy(union)
         self.o("}")
         self.o()
@@ -1113,10 +1111,8 @@ class Generator:
     def generate_enum(self, node: Enum) -> None:
         self.output_doc(node, "")
         self.o("export enum %s {" % node.name)
-        index = 0
         for ev in node.members:
             self.o("    %s," % (self.value(ev.identifier)))
-            index += 1
         self.o("}")
         self.o()
 


### PR DESCRIPTION
This additionally fixes a bug where unions in python generator skips removed commands without incrementing the counter